### PR TITLE
Don't trim textContent of attributes

### DIFF
--- a/common/parser.js
+++ b/common/parser.js
@@ -106,9 +106,9 @@ function collectAttributes(model, defaults, element) {
     spec = model[key];
 
     if (typeof spec === 'undefined')
-      attr[key] = dataElement.textContent.trim();
+      attr[key] = dataElement.textContent;
     else
-      attr[spec.name] = spec.cast(dataElement.textContent.trim());
+      attr[spec.name] = spec.cast(dataElement.textContent);
   }
 
   for (key in defaults) {


### PR DESCRIPTION
`graphology-graphml` shouldn't be throwing away whitespace from attribute values. This causes files to parse differently than with other GraphML implementations (e.g., Python's `networkx`).